### PR TITLE
v1.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 *.vscode
 
 /vendor
+/LOCALNOTES

--- a/accepter.go
+++ b/accepter.go
@@ -119,6 +119,7 @@ func (a *Accepter) ListenAndServe(network, address string) error {
 	if err != nil {
 		return err
 	}
+	defer lis.Close()
 	return a.Serve(lis)
 }
 
@@ -136,6 +137,7 @@ func (a *Accepter) ListenAndServeTLS(network, address string, certFile, keyFile 
 	if err != nil {
 		return err
 	}
+	defer lis.Close()
 	return a.ServeTLS(lis, certFile, keyFile)
 }
 


### PR DESCRIPTION
- bug fix: memory leak when Serve returned ErrAlreadyServed or ServeTLS returned any TLS error or ErrAlreadyServed.