### PR TITLE
v1.2.7

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,36 @@
+package accepter
+
+import (
+	"errors"
+	"fmt"
+)
+
+// TLSError is returned when a method fails with TLS error
+type TLSError struct {
+	err error
+}
+
+func wrapTLSError(err error) error {
+	return &TLSError{
+		err: err,
+	}
+}
+
+// Error is implementation of error
+func (e *TLSError) Error() string {
+	s := "tls error"
+	if e.err == nil {
+		return s
+	}
+	return fmt.Sprintf("%s: %v", s, e.err)
+}
+
+// Unwrap returns wrapped error
+func (e *TLSError) Unwrap() error {
+	return e.err
+}
+
+var (
+	// ErrAlreadyServed is returned when Serve or ServeTLS method has been already called
+	ErrAlreadyServed = errors.New("the accepter has already served")
+)

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 )
 
+var (
+	// ErrAlreadyServed is returned when Serve or ServeTLS method has been already called
+	ErrAlreadyServed = errors.New("the accepter has already served")
+)
+
 // TLSError is returned when a method fails with TLS error
 type TLSError struct {
 	err error
@@ -29,8 +34,3 @@ func (e *TLSError) Error() string {
 func (e *TLSError) Unwrap() error {
 	return e.err
 }
-
-var (
-	// ErrAlreadyServed is returned when Serve or ServeTLS method has been already called
-	ErrAlreadyServed = errors.New("the accepter has already served")
-)


### PR DESCRIPTION
* added TLSError and error.go to describe TLSError and other errors while returning errors